### PR TITLE
replace docker with dockerd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifdef CONTAINERIZED_BUILD
 	touch $@
 
 ubuntu.sqsh:
-	enroot import -o $@ docker://ubuntu:$(UBUNTU_VERSION)
+	enroot import -o $@ dockerd://ubuntu:$(UBUNTU_VERSION)
 
 mostlyclean:
 	-enroot remove -f $(CONTAINER_NAME)


### PR DESCRIPTION
with docker, we run into the following issue with enroot:
```bash
ubuntu@ip-172-31-5-178:~/nephele$ enroot import docker://ubuntu
[INFO] Querying registry for permission grant
[INFO] Authenticating with user: <anonymous>
[INFO] Authentication succeeded
[INFO] Fetching image manifest list
[INFO] Fetching image manifest
[ERROR] URL https://registry-1.docker.io/v2/library/ubuntu/manifests/latest returned error code: 404 Not Found
```